### PR TITLE
Travis: Update Node.js to 12 and make their execution a bit faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,9 @@ node_js:
   - "6"
   - "8"
   - "10"
-  - "11"
+  - "12"
+cache:
+  directories:
+    - node_modules
+matrix:
+  fast_finish: true


### PR DESCRIPTION
This updates Node.js from 11 to 12, and make the test matrix a bit faster.