### PR TITLE
47: Fix BrowserVersion Errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-browser-provider-lambdatest",
-  "version": "2.0.25",
+  "version": "2.0.27",
   "description": "lambdatest TestCafe browser provider plugin.",
   "repository": "https://github.com/LambdaTest/testcafe-browser-provider-lambdatest",
   "homepage": "https://github.com/LambdaTest/testcafe-browser-provider-lambdatest",

--- a/src/util.js
+++ b/src/util.js
@@ -282,12 +282,9 @@ async function _parseCapabilities (id, capability) {
 
         if (browserName && browserName.trim().toLowerCase() === 'safari' && browserVersion && browserVersion.split('.')[0] > 11 && !('enableCustomTranslation' in capabilities[id])) capabilities[id].enableCustomTranslation = true;
 
-        if (!browserVersion || browserVersion === 'any') {
-
+        if (!browserVersion || browserVersion === 'any' && additionalCapabilities[capability] !== undefined) {
             const browserVersionKey = additionalCapabilities[capability]['browserVersion'];
-
             if (browserName && browserName.trim().toLowerCase() === 'firefox' && browserVersionKey && browserVersionKey.split('.')[0] > 47 && !('enableCustomTranslation' in capabilities[id])) capabilities[id].enableCustomTranslation = true;
-
             if (browserName && browserName.trim().toLowerCase() === 'safari' && browserVersionKey && browserVersionKey.split('.')[0] > 11 && !('enableCustomTranslation' in capabilities[id])) capabilities[id].enableCustomTranslation = true;
             
 


### PR DESCRIPTION
This PR fixes issue #47  as the code makes an assumption that the additionalCapabilities object that gets initialized to an empty object will always be populated with keys that exist, in reality they won't be if LT_CAPABILITY_PATH is not set.

Added a guard check for this to resolve the issue.